### PR TITLE
configure docker-compose to wait for the db to be healthy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,8 @@ services:
     image: "kpi-dashboard"
     container_name: "kpi-dashboard"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       POSTGRES_PASSWORD: admin
       POSTGRES_USER: admin
@@ -29,6 +30,11 @@ services:
       - POSTGRES_PASSWORD=admin
       - POSTGRES_USER=admin
       - POSTGRES_DB=admin
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - kpi-dashboard
 


### PR DESCRIPTION
**PR** fixes the error that appeared after fresh build of the application using `docker compose up --build`

kpi-dashboard  | psycopg2.OperationalError: connection to server at "postgres" (172.18.0.2), port 5432 failed: Connection refused

**Cause:** 
The error appeared because when first built the application starts up before the database initialization is finished. 

**Fix:** 
The fix includes additional configuration in the docker-compose.yml file to ensure that the Flask app waits for the database service to be ready to accept connections before starting.

**Testing:** 
1) Remove all docker containers `docker container prune`
2) Rebuild the application `docker compose up --build`