### PR TITLE
✨ Add HTTPS Enforcement on OIDC Callback

### DIFF
--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 env:
   AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
   AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 env:
   AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
   AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/app/app.py
+++ b/app/app.py
@@ -34,7 +34,12 @@ def create_app() -> Flask:
     app.title = "⚙️ OE - KPI Dashboard"
     app.layout = create_dashboard(server.figure_service)
 
-    auth = OIDCAuth(app, secret_key=app_config.flask.app_secret_key)
+    auth = OIDCAuth(
+        app,
+        secret_key=app_config.flask.app_secret_key,
+        force_https_callback=True,
+        secure_session=True,
+    )
     auth.register_provider(
         "idp",
         token_endpoint_auth_method="client_secret_post",


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4739

## ♻️ What's changed

- Enforce HTTPS on the callback URL
- Added Secure Cookie Configuration

## 📝 Notes

- This is required for the current callback to work in Auth0, since we only callback to HTTPS to ensure messages are encrypted