### PR TITLE
✨ Add Sentry Quota Graphs

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -34,19 +34,20 @@ def create_app() -> Flask:
     app.title = "⚙️ OE - KPI Dashboard"
     app.layout = create_dashboard(server.figure_service)
 
-    auth = OIDCAuth(
-        app,
-        secret_key=app_config.flask.app_secret_key,
-        force_https_callback=True,
-        secure_session=True,
-    )
-    auth.register_provider(
-        "idp",
-        token_endpoint_auth_method="client_secret_post",
-        client_id=app_config.auth0.client_id,
-        client_secret=app_config.auth0.client_secret,
-        server_metadata_url=f"https://{app_config.auth0.domain}/.well-known/openid-configuration",
-    )
+    if app_config.auth_enabled:
+        auth = OIDCAuth(
+            app,
+            secret_key=app_config.flask.app_secret_key,
+            force_https_callback=True,
+            secure_session=True,
+        )
+        auth.register_provider(
+            "idp",
+            token_endpoint_auth_method="client_secret_post",
+            client_id=app_config.auth0.client_id,
+            client_secret=app_config.auth0.client_secret,
+            server_metadata_url=f"https://{app_config.auth0.domain}/.well-known/openid-configuration",
+        )
     logger.info("Running app...")
 
     return app.server
@@ -77,6 +78,31 @@ def create_dashboard(figure_service: FigureService):
                     figure=figure_service.get_support_stats_current_month(),
                     style={
                         "width": "100%",
+                        "height": "500px",
+                        "display": "inline-block",
+                    },
+                ),
+                html.H2("Sentry Quota"),
+                dcc.Graph(
+                    figure=figure_service.get_sentry_transactions_usage(),
+                    style={
+                        "width": "100%",
+                        "height": "500px",
+                        "display": "inline-block",
+                    },
+                ),
+                dcc.Graph(
+                    figure=figure_service.get_sentry_errors_usage(),
+                    style={
+                        "width": "50%",
+                        "height": "500px",
+                        "display": "inline-block",
+                    },
+                ),
+                dcc.Graph(
+                    figure=figure_service.get_sentry_replays_usage(),
+                    style={
+                        "width": "50%",
                         "height": "500px",
                         "display": "inline-block",
                     },

--- a/app/config/app_config.py
+++ b/app/config/app_config.py
@@ -6,20 +6,24 @@ def __get_env_var(name: str) -> str | None:
     return os.getenv(name)
 
 
-def __get_env_var_as_boolean(name: str) -> bool | None:
+def __get_env_var_as_boolean(name: str, default: bool) -> bool | None:
     value = __get_env_var(name)
 
     if value is None:
-        return False
+        return default
 
     if value.lower() == "true":
         return True
 
-    return False
+    if value.lower() == "false":
+        return False
+
+    return default
 
 
 app_config = SimpleNamespace(
     api_key=__get_env_var("API_KEY"),
+    auth_enabled=__get_env_var_as_boolean("AUTH_ENABLED", True),
     auth0=SimpleNamespace(
         domain=__get_env_var("AUTH0_DOMAIN"),
         client_id=__get_env_var("AUTH0_CLIENT_ID"),

--- a/app/services/figure_service.py
+++ b/app/services/figure_service.py
@@ -213,3 +213,85 @@ class FigureService:
         )
 
         return fig_github_actions_quota_usage
+
+    def get_sentry_transactions_usage(self):
+        sentry_transaction_quota_consumed = pd.DataFrame(
+            self.database_service.get_indicator(
+                "SENTRY_TRANSACTIONS_USED_OVER_PAST_DAY"
+            ),
+            columns=["timestamp", "count"],
+        ).sort_values(by="timestamp", ascending=True)
+
+        fig_stubbed_sentry_transactions_used = px.line(
+            sentry_transaction_quota_consumed,
+            x="timestamp",
+            y="count",
+            title="Sentry Transactions Used",
+            markers=True,
+            template="plotly_dark",
+        )
+        fig_stubbed_sentry_transactions_used.add_hline(
+            y=967741, annotation_text="Max Daily Usage"
+        )
+        fig_stubbed_sentry_transactions_used.add_hrect(
+            y0=(967741 * 0.8),
+            y1=967741,
+            line_width=0,
+            fillcolor="red",
+            opacity=0.2,
+            annotation_text="Alert Threshold",
+        )
+
+        return fig_stubbed_sentry_transactions_used
+
+    def get_sentry_errors_usage(self):
+        sentry_errors_quota_consumed = pd.DataFrame(
+            self.database_service.get_indicator("SENTRY_ERRORS_USED_OVER_PAST_DAY"),
+            columns=["timestamp", "count"],
+        ).sort_values(by="timestamp", ascending=True)
+
+        fig_sentry_erros_used = px.line(
+            sentry_errors_quota_consumed,
+            x="timestamp",
+            y="count",
+            title="Errors Used",
+            markers=True,
+            template="plotly_dark",
+        )
+        fig_sentry_erros_used.add_hline(y=129032, annotation_text="Max Daily Usage")
+        fig_sentry_erros_used.add_hrect(
+            y0=(129032 * 0.8),
+            y1=129032,
+            line_width=0,
+            fillcolor="red",
+            opacity=0.2,
+            annotation_text="Alert Threshold",
+        )
+
+        return fig_sentry_erros_used
+
+    def get_sentry_replays_usage(self):
+        sentry_replays_quota_consumed = pd.DataFrame(
+            self.database_service.get_indicator("SENTRY_REPLAYS_USED_OVER_PAST_DAY"),
+            columns=["timestamp", "count"],
+        ).sort_values(by="timestamp", ascending=True)
+
+        fig_sentry_replays_used = px.line(
+            sentry_replays_quota_consumed,
+            x="timestamp",
+            y="count",
+            title="Replays Used",
+            markers=True,
+            template="plotly_dark",
+        )
+        fig_sentry_replays_used.add_hline(y=25806, annotation_text="Max Daily Usage")
+        fig_sentry_replays_used.add_hrect(
+            y0=(25806 * 0.8),
+            y1=25806,
+            line_width=0,
+            fillcolor="red",
+            opacity=0.2,
+            annotation_text="Alert Threshold",
+        )
+
+        return fig_sentry_replays_used

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     image: "kpi-dashboard"
     container_name: "kpi-dashboard"
     environment:
+      AUTH_ENABLED: false
       POSTGRES_PASSWORD: admin
       POSTGRES_USER: admin
       POSTGRES_DB: admin


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4761

## ♻️ What's changed

- Added graphs which display usage over time for Sentry Transactions, Errors and Replays Quota
- Added a feature toggle to optionally disable Authentication (mainly so we don't need to set up Auth0 for local development)

## 📝 Notes

- Ran locally and the graph looks like this (with some stubbed data)

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/b9485037-7f41-4ee8-a802-3638f97a4fab">
