### PR TITLE
✨ Add `/api/indicator/add` as a Public Route

### DIFF
--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 env:
   AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
   AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 env:
   AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
   AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/app/app.py
+++ b/app/app.py
@@ -41,7 +41,7 @@ def create_app() -> Flask:
             force_https_callback=True,
             secure_session=True,
         )
-        add_public_routes(app, public_routes=["/api"])
+        add_public_routes(app, routes=["/api"])
         auth.register_provider(
             "idp",
             token_endpoint_auth_method="client_secret_post",

--- a/app/app.py
+++ b/app/app.py
@@ -1,7 +1,7 @@
 import logging
 
 from dash import Dash, dcc, html
-from dash_auth import OIDCAuth
+from dash_auth import OIDCAuth, add_public_routes
 from flask import Flask
 
 from app.config.app_config import app_config
@@ -41,6 +41,7 @@ def create_app() -> Flask:
             force_https_callback=True,
             secure_session=True,
         )
+        add_public_routes(app, public_routes=["/api"])
         auth.register_provider(
             "idp",
             token_endpoint_auth_method="client_secret_post",

--- a/app/app.py
+++ b/app/app.py
@@ -41,7 +41,7 @@ def create_app() -> Flask:
             force_https_callback=True,
             secure_session=True,
         )
-        add_public_routes(app, routes=["/api/"])
+        add_public_routes(app, routes=["/api/indicator/add"])
         auth.register_provider(
             "idp",
             token_endpoint_auth_method="client_secret_post",

--- a/app/app.py
+++ b/app/app.py
@@ -41,7 +41,7 @@ def create_app() -> Flask:
             force_https_callback=True,
             secure_session=True,
         )
-        add_public_routes(app, routes=["/api"])
+        add_public_routes(app, routes=["/api/"])
         auth.register_provider(
             "idp",
             token_endpoint_auth_method="client_secret_post",


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4761
- To allow other processes to access the ``/api/indicator/add`` route via the X-API-KEY header instead of Auth0

## ♻️ What's changed

- Added ``/api/indicator/add`` as a public route

## 📝 Notes

- Hitting the endpoint locally you receive a 302 response to Auth0 - this should be a 403 response instead to indicate the API Key is wrong

```shell
$ curl -X POST https://kpi-dashboard.cloud-platform.service.justice.gov.uk/api/indicator/add -H "X-API-KEY:test"  -H "Content-Type: application/json" -d '{"indicator":"testing", "count": 900000 }'
```