### PR TITLE
Change db service to healthy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - "4567:4567"
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
         restart: true
     networks:
       - kpi-dashboard
@@ -33,7 +33,7 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_DB=admin
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U admin"]
+      test: [ "CMD-SHELL", "pg_isready -U admin" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This PR is to add back in the functionality for the db service to show as healthy before the app container starts.  This was removed by accident in a previous commit:

- docker-compose.yaml updated to add this functionality