### PR TITLE
Fixed error when add_indicator method is called

### DIFF
--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -21,8 +21,7 @@ class DatabaseService:
             logging.info("Executing query...")
             cur = conn.cursor()
             cur.execute(sql, values)
-            data = None
-            # Only fetch results if the query return rows
+            data = None 
             if cur.description is not None:
                 try:
                     data = cur.fetchall()

--- a/app/services/database_service.py
+++ b/app/services/database_service.py
@@ -22,10 +22,13 @@ class DatabaseService:
             cur = conn.cursor()
             cur.execute(sql, values)
             data = None
-            try:
-                data = cur.fetchall()
-            except Exception as e:
-                logging.error(e)
+            # Only fetch results if the query return rows
+            if cur.description is not None:
+                try:
+                    data = cur.fetchall()
+                except Exception as e:
+                    logging.error(e)
+            
             conn.commit()
             return data
 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- PR fixes the error "no results to fetch" appeared in app logs when POST request is made to the add_indicator endpoint. 
` ERROR | database_service.py:30 | no results to fetch`

Findings: 
- add_indicator method from the database_service called __execute_query to perform an INSERT operation
- The __execute_query method always attempts to call cur.fetchall(), regardless of the query type
- Some queries types (e g. INSERT, UPDATE, or DELETE) do not return rows so the error is returned.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- `cur.description is not None` added to it has to be true before calling cur.fetchall().
This attribute would be set to None for queries that do not return rows (e.g  INSERT, UPDATE, or DELETE). 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- Testing: 
1) Run the app locally docker compose up --build
2) Send add_indicator post request: `curl -X POST http://localhost:4567/api/indicator/add -H "X-API-KEY:test"  -H "Content-Type: application/json" -v -d '{"indicator":"testing with aga", "count": 900000 }'`
3)  Verify if there is no ` ERROR | database_service.py:30 | no results to fetch` in the kpi-dashboard logs.

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.