### PR TITLE
Add Vulnerability Template + Use Commit Hash

### DIFF
--- a/.github/ISSUE_TEMPLATE/trivy-vulnerability-template.md
+++ b/.github/ISSUE_TEMPLATE/trivy-vulnerability-template.md
@@ -1,0 +1,27 @@
+---
+name: Trivy Vulnerability Scan Report - {{ date | date('YYYY-MM-DD') }}
+about: Create an issue for vulnerabilities that need addressing
+title: Trivy Vulnerability Scan Report - {{ date | date('YYYY-MM-DD') }}
+labels: risk
+assignees: ''
+
+---
+
+## Trivy Vulnerability Scan Results
+
+A Trivy vulnerability scan has been conducted, revealing vulnerabilities across different severity levels.
+
+### Action Required
+
+It's important that the team addresses these vulnerabilities as soon as possible to maintain the security integrity of our codebase. Please review the detailed scan results attached to the GitHub Security tab and initiate the necessary updates or patches.
+
+If a solution is not possible at this time, please raise it with the team for further discussion.
+
+### Results
+
+Please refer to the [GitHub Security tab] (https://github.com/ministryofjustice/operations-engineering-kpi-dashboard/security/code-scanning) for a detailed breakdown of each vulnerability found, including the package name, affected versions, and recommended fixes.
+
+### Resources
+
+- [Trivy GitHub Action](https://github.com/aquasecurity/trivy-action)
+- [Understanding the GitHub Security Tab](https://docs.github.com/en/code-security/security-advisories/about-github-security-advisories)

--- a/.github/workflows/cicd-trivy-dependency-scan.yml
+++ b/.github/workflows/cicd-trivy-dependency-scan.yml
@@ -20,7 +20,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@af56b044b5d41c317aef5d19920b3183cb4fbbec # v3
         with:
           sarif_file: "trivy-results.sarif"
 


### PR DESCRIPTION
This pull request introduces a new issue template for Trivy vulnerability scan reports and updates the CI/CD workflow to use a specific commit of the `upload-sarif` action. The most important changes are detailed below:

### New Issue Template:

* [`.github/ISSUE_TEMPLATE/trivy-vulnerability-template.md`](diffhunk://#diff-63b1e62c02dfecc9bf9b00350d47b68435e9c53eba2c658fc164c5ecc081a67cR1-R27): Added a new issue template for Trivy vulnerability scan reports, which includes sections for scan results, action required, and resources.

### CI/CD Workflow Update:

* [`.github/workflows/cicd-trivy-dependency-scan.yml`](diffhunk://#diff-7910b1676c8079cc8c01f90962af36e87051c5d5ce91da2bdd0951256e20ea83L23-R23): Updated the `upload-sarif` action to use a specific commit (`af56b044b5d41c317aef5d19920b3183cb4fbbec`) instead of the version tag `v3`.