### PR TITLE
:recycle: Update gunicorn version to 23.0.0 and adjust Python version in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,12 +7,14 @@ name = "pypi"
 authlib = "==1.3.1"
 dash_auth = "==2.3.0"
 flask = "==3.0.0"
-gunicorn = "==21.2.0"
 psycopg2-binary = "2.9.9"
 plotly = "==5.21.0"
 dash = "==2.16.1"
 pandas = "==2.2.2"
 statsmodels = "==0.14.1"
+gunicorn = "==23.0.0"
 
 [requires]
 python_version = "3.12"
+
+[dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5050b4dfb9dcbd969ba1598fa86196e8f44624500c43780497968ac83268840e"
+            "sha256": "b7dee6c6e22417c29f7e9f62b86934fd79534cd013c51ccd388692e61871e0a0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -301,12 +301,12 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0",
-                "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"
+                "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d",
+                "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
-            "version": "==21.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0.0"
         },
         "idna": {
             "hashes": [
@@ -458,11 +458,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.1"
+            "version": "==24.2"
         },
         "pandas": {
             "hashes": [


### PR DESCRIPTION
This commit fixes:
```
-> Vulnerability found in gunicorn version 22.0.0
   Vulnerability ID: 72809
   Affected spec: >=22.0.0,<23.0.0
   ADVISORY: A vulnerability in Gunicorn allowed the TolerateDangerousFraming setting to process conflicting headers
   (Transfer-Encoding and Content-Length) and dangerous characters in HTTP header fields. This could lead to HTTP request...
   PVE-2024-72809
   For more information, please visit https://data.safetycli.com/v/72809/742
```