### PR TITLE
fixed bug in gha quote figure service

### DIFF
--- a/app/services/figure_service.py
+++ b/app/services/figure_service.py
@@ -189,6 +189,7 @@ class FigureService:
             columns=["timestamp", "count"],
         ).sort_values(by="timestamp", ascending=True)
 
+
         fig_github_actions_quota_usage_cumulative = px.line(
             github_actions_quota_usage_cumulative,
             x="timestamp",
@@ -206,6 +207,9 @@ class FigureService:
         fig_github_actions_quota_usage_cumulative.update_layout(
             yaxis_title="Min used"
         )
+
+        if github_actions_quota_usage_cumulative.shape[0] < 1: 
+            return fig_github_actions_quota_usage_cumulative, None
 
         # Add quota reset lines
         start_date = github_actions_quota_usage_cumulative['timestamp'].min().date()
@@ -241,13 +245,13 @@ class FigureService:
         fig_github_actions_quota_usage_daily.update_layout(
             yaxis_title="Min used"
         )
-
-        fig_github_actions_quota_usage_daily.add_hline(
-            y=github_actions_quota_usage_daily['Daily_minutes'].median(),
-            line=dict(color="red", dash="dash"),  # Custom line style
-            annotation_text="Median",
-            annotation_position="top right"
-        )
+        if github_actions_quota_usage_daily.shape[0] > 0:
+            fig_github_actions_quota_usage_daily.add_hline(
+                y=github_actions_quota_usage_daily['Daily_minutes'].median(),
+                line=dict(color="red", dash="dash"),  # Custom line style
+                annotation_text="Median",
+                annotation_position="top right"
+            )
 
         return fig_github_actions_quota_usage_cumulative, fig_github_actions_quota_usage_daily
 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

-  This PR includes fix for the bug in figure service that was preventing Flask app to start if there is no 'ENTERPRISE_GITHUB_ACTIONS_QUOTA_USAGE' in the DB. This was causing problems when spinning the app in local environment. 

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Updates in the figure service functions where gha quota graphs are generated

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- NA

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.