### PR TITLE
Fetch eterprise usage report

### DIFF
--- a/fetcher/bin/fetch_usage_report_daily.py
+++ b/fetcher/bin/fetch_usage_report_daily.py
@@ -1,0 +1,34 @@
+import logging
+from datetime import datetime, timedelta
+import os
+from fetcher.services.github_service import GithubService
+
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def _get_environment_variables() -> str:
+
+    github_token = os.getenv("GH_TOKEN")
+    if not github_token:
+        raise ValueError(
+            "The env variable GH_TOKEN is empty or missing")
+
+    return github_token
+
+
+def fetch_usage_report_daily():
+
+    github_token = _get_environment_variables()
+    github_service = GithubService(github_token)
+    yesterday = (datetime.today() - timedelta(days=1)).day
+    daily_usage_report_json = github_service.get_current_daily_usage_for_enterprise(day=yesterday)
+
+    '''Code for uploading results to the DB needs to be added here.'''
+
+
+if __name__ == "__main__":
+    fetch_usage_report_daily()

--- a/fetcher/tests/test_usage_report_daily.py
+++ b/fetcher/tests/test_usage_report_daily.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+import pytest
+from bin.fetch_usage_report_daily import _get_environment_variables, fetch_usage_report_daily
+
+
+class TestFetchGithubActionsQuota:
+
+    def test_get_environment_variables(self, mocker):
+
+        mock_getenv = mocker.patch("os.getenv")
+        mock_getenv.return_value = "token_mock"
+
+        result = _get_environment_variables()
+
+        assert result == "token_mock"
+
+    def test_get_environment_variables_missing_token(self, mocker):
+
+        mock_getenv = mocker.patch("os.getenv")
+        mock_getenv.return_value = None
+
+        with pytest.raises(ValueError) as err:
+            _get_environment_variables()
+
+        assert str(err.value) == (
+            "The env variable GH_TOKEN is empty or missing"
+        )
+
+    def test_fetch_usage_report_daily(self, mocker):
+
+        mock_get_environment_variables = mocker.patch(
+            "bin.fetch_usage_report_daily._get_environment_variables"
+        )
+        mock_get_environment_variables.return_value = "token_mock"
+        mock_get_current_daily_usage_for_enterprise = mocker.patch(
+            "bin.fetch_usage_report_daily.GithubService.get_current_daily_usage_for_enterprise")
+
+        fetch_usage_report_daily()
+
+        yesterday = (datetime.today() - timedelta(days=1)).day
+
+        mock_get_environment_variables.assert_called_once()
+        mock_get_current_daily_usage_for_enterprise.assert_called_with(day=yesterday) 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

-  Added code to retrieve daily usage report data from the GitHub API, which provides exact usage details for the entire enterprise, broken down by repository and organization.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added fetcher/bin/fetch_usage_report_daily 
- Added get_current_daily_usage_for_enterprise method to fetcher/services/github_service
- Updated unit tests acordingly 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- [#5045 ](https://github.com/ministryofjustice/operations-engineering/issues/5045)

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.