### PR TITLE
rolled back to 3.12.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm
+FROM python:3.12.8-slim-bookworm
 
 LABEL maintainer="operations-engineering <operations-engineering@digital.justice.gov.uk>"
 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose
 
- Rolled back to python:3.12.8-slim-bookworm

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- version 3.13-slim-bookworm caused build to fail: 
https://github.com/ministryofjustice/operations-engineering-kpi-dashboard/actions/runs/15183619541/job/42698778679

I have tested locally and it works for Rolled back to python:3.12.8-slim-bookworm


<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- [#5356](https://github.com/ministryofjustice/operations-engineering/issues/5356) 

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.